### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/Lab 2 - Working with Hubway Data/Solution/HubwayFunctions/.vscode/extensions.json
+++ b/Lab 2 - Working with Hubway Data/Solution/HubwayFunctions/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }

--- a/Setting up the Laptop/README.md
+++ b/Setting up the Laptop/README.md
@@ -48,7 +48,7 @@ What are Visual Studio Code Extensions? Extensions let you add languages, debugg
 - Azure Account, type: **```code --install-extension ms-vscode.azure-account```**
 - Azure Functions, type: **```code --install-extension ms-azuretools.vscode-azurefunctions```**
 - Azure IoT Device Workbench, type: **```code --install-extension vsciot-vscode.vscode-iot-workbench```**
-- C#, type: **```code --install-extension ms-vscode.csharp```**
+- C#, type: **```code --install-extension ms-dotnettools.csharp```**
 - Material Icon Theme, type: **```code --install-extension pkief.material-icon-theme```**
 - NuGet Package Manager, type: **```code --install-extension jmrog.vscode-nuget-package-manager```**
 - Azure CLI Tools, type: **```code --install-extension ms-vscode.azurecli```**


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)