### PR TITLE
Update C# extension name

### DIFF
--- a/Lab 2 - Working with Hubway Data/Solution/HubwayFunctions/.vscode/extensions.json
+++ b/Lab 2 - Working with Hubway Data/Solution/HubwayFunctions/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }


### PR DESCRIPTION
ms-vscode.csharp is now ms-dotnettools.csharp